### PR TITLE
Removed unused struct

### DIFF
--- a/src/Computerscare.hpp
+++ b/src/Computerscare.hpp
@@ -275,16 +275,7 @@ struct ComputerscareBlueLight : ModuleLightWidget {
 	}
 };
 
-
-
-
 */
-template <typename BASE>
-struct MuteLight : BASE {
-	MuteLight() {
-		this->box.size = mm2px(Vec(6.f, 6.f));
-	}
-};
 
 template <typename BASE>
 struct ComputerscareHugeLight : BASE  {


### PR DESCRIPTION
This pull request removes the struct "MuteLight" because it is never used outside of its declaration. In other words, the struct is defined, but never used elsewhere in the code, so it would be better to remove the unused code.