### PR TITLE
Fix Metarbo build errors: use Rack v2 ModuleWidget API

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -169,6 +169,12 @@
 			"tags": ["Sequencer", "Clock Modulator", "Polyphonic"],
 			"manualUrl":
 				"https://github.com/freddyz/computerscare-vcv-modules/blob/master/doc/horse-a-doodle-do.md"
+		},
+		{
+			"slug": "computerscare-metarbo",
+			"name": "Metarbo",
+			"description": "Flexible-width polyphonic signal processor with multiple view modes",
+			"tags": ["Polyphonic", "Utility"]
 		}
 	]
 }

--- a/src/Computerscare.cpp
+++ b/src/Computerscare.cpp
@@ -27,4 +27,6 @@ void init(Plugin *p) {
 	p->addModel(modelComputerscareHorseADoodleDoo);
 
 	p->addModel(modelComputerscareTolyPoolsV2);
+
+	p->addModel(modelComputerscareMetarbo);
 }

--- a/src/Computerscare.hpp
+++ b/src/Computerscare.hpp
@@ -37,6 +37,8 @@ extern Model *modelComputerscareDrolyPaw;
 
 extern Model *modelComputerscareTolyPoolsV2;
 
+extern Model *modelComputerscareMetarbo;
+
 static const NVGcolor COLOR_COMPUTERSCARE_LIGHT_GREEN = nvgRGB(0xC0, 0xE7, 0xDE);
 static const NVGcolor COLOR_COMPUTERSCARE_GREEN = nvgRGB(0x24, 0xc9, 0xa6);
 static const NVGcolor COLOR_COMPUTERSCARE_RED = nvgRGB(0xC4, 0x34, 0x21);

--- a/src/Metarbo/ComputerscareMetarbo.cpp
+++ b/src/Metarbo/ComputerscareMetarbo.cpp
@@ -1,0 +1,185 @@
+#include "ComputerscareMetarbo.hpp"
+#include "MetarboIOView.hpp"
+#include "MetarboControlsIOView.hpp"
+#include "MetarboFullView.hpp"
+
+// View mode switch button - clickable to cycle, also in right-click menu
+struct MetarboViewModeSwitch : SvgSwitch {
+  ComputerscareMetarbo* metarbo;
+
+  MetarboViewModeSwitch() {
+    addFrame(APP->window->loadSvg(
+        asset::plugin(pluginInstance, "res/iso-3way-1.svg")));
+    addFrame(APP->window->loadSvg(
+        asset::plugin(pluginInstance, "res/iso-3way-2.svg")));
+    addFrame(APP->window->loadSvg(
+        asset::plugin(pluginInstance, "res/iso-3way-3.svg")));
+    shadow->opacity = 0.f;
+  }
+};
+
+struct ComputerscareMetarboWidget : ModuleWidget {
+  ComputerscareMetarbo* metarboModule;
+  BGPanel* bgPanel;
+  MetarboSquareDisplay* squareDisplay = nullptr;
+  MetarboViewMode lastViewMode = VIEW_IO_ONLY;
+  bool initialized = false;
+
+  ComputerscareMetarboWidget(ComputerscareMetarbo* module) {
+    setModule(module);
+    metarboModule = module;
+
+    // Start with IO_ONLY width
+    float startWidth = metarboViewWidths[VIEW_IO_ONLY] * RACK_GRID_WIDTH;
+    box.size = Vec(startWidth, RACK_GRID_HEIGHT);
+
+    // Background panel
+    bgPanel = new BGPanel(COLOR_COMPUTERSCARE_LIGHT_GREEN);
+    bgPanel->box.size = box.size;
+    addChild(bgPanel);
+
+    // Build initial view
+    rebuildView(module ? module->viewMode : VIEW_IO_ONLY);
+    initialized = true;
+  }
+
+  void clearAllPortsAndParams() {
+    // Remove all inputs
+    for (PortWidget* pw : getInputs()) {
+      removeChild(pw);
+      delete pw;
+    }
+    // Remove all outputs
+    for (PortWidget* pw : getOutputs()) {
+      removeChild(pw);
+      delete pw;
+    }
+    // Remove all params
+    for (ParamWidget* pw : getParams()) {
+      removeChild(pw);
+      delete pw;
+    }
+    // Remove square display if present
+    if (squareDisplay) {
+      removeChild(squareDisplay);
+      delete squareDisplay;
+      squareDisplay = nullptr;
+    }
+  }
+
+  void rebuildView(MetarboViewMode mode) {
+    clearAllPortsAndParams();
+
+    float newWidth;
+
+    // Add view mode switch at top - present in all views
+    addParam(createParam<MetarboViewModeSwitch>(
+        Vec(4, 16), metarboModule, ComputerscareMetarbo::VIEW_MODE_PARAM));
+
+    switch (mode) {
+      case VIEW_IO_ONLY:
+        newWidth = MetarboIOView::getWidth();
+        MetarboIOView::addPorts(this, metarboModule);
+        break;
+
+      case VIEW_CONTROLS_IO:
+        newWidth = MetarboControlsIOView::getWidth();
+        MetarboControlsIOView::addControls(this, metarboModule);
+        MetarboControlsIOView::addPorts(this, metarboModule);
+        break;
+
+      case VIEW_FULL: {
+        newWidth = MetarboFullView::getWidth();
+        MetarboFullView::addControls(this, metarboModule);
+        MetarboFullView::addPorts(this, metarboModule);
+
+        // Add square display in the middle
+        squareDisplay = new MetarboSquareDisplay(metarboModule);
+        float squareX = 30.f + 34.f;  // after controls + inputs column
+        float squareY = (RACK_GRID_HEIGHT - 150.f) / 2.f;
+        squareDisplay->box.pos = Vec(squareX, squareY);
+        addChild(squareDisplay);
+        break;
+      }
+
+      default:
+        newWidth = MetarboIOView::getWidth();
+        MetarboIOView::addPorts(this, metarboModule);
+        break;
+    }
+
+    // Resize module
+    box.size.x = newWidth;
+    bgPanel->box.size.x = newWidth;
+
+    lastViewMode = mode;
+  }
+
+  void step() override {
+    if (metarboModule) {
+      MetarboViewMode currentMode = metarboModule->viewMode;
+      if (currentMode != lastViewMode) {
+        rebuildView(currentMode);
+      }
+    }
+    ModuleWidget::step();
+  }
+
+  void appendContextMenu(Menu* menu) override {
+    ComputerscareMetarbo* mod =
+        dynamic_cast<ComputerscareMetarbo*>(this->module);
+    if (!mod) return;
+
+    menu->addChild(new MenuSeparator());
+    menu->addChild(createMenuLabel("View Mode"));
+
+    for (int i = 0; i < NUM_VIEW_MODES; i++) {
+      struct ViewModeItem : MenuItem {
+        ComputerscareMetarbo* module;
+        int mode;
+        void onAction(const event::Action& e) override {
+          module->viewMode = (MetarboViewMode)mode;
+          module->params[ComputerscareMetarbo::VIEW_MODE_PARAM].setValue(
+              (float)mode);
+        }
+        void step() override {
+          rightText = CHECKMARK((int)module->viewMode == mode);
+          MenuItem::step();
+        }
+      };
+
+      ViewModeItem* item = new ViewModeItem();
+      item->text = metarboViewModeNames[i];
+      item->module = mod;
+      item->mode = i;
+      menu->addChild(item);
+    }
+
+    menu->addChild(new MenuSeparator());
+    menu->addChild(createMenuLabel("Program"));
+
+    for (int i = 0; i < 4; i++) {
+      struct ProgramItem : MenuItem {
+        ComputerscareMetarbo* module;
+        int program;
+        void onAction(const event::Action& e) override {
+          module->currentProgram = program;
+        }
+        void step() override {
+          rightText = CHECKMARK(module->currentProgram == program);
+          MenuItem::step();
+        }
+      };
+
+      ProgramItem* item = new ProgramItem();
+      item->text = "Program " + std::to_string(i + 1) + " (pass-through)";
+      item->module = mod;
+      item->program = i;
+      menu->addChild(item);
+    }
+  }
+};
+
+Model* modelComputerscareMetarbo =
+    createModel<ComputerscareMetarbo, ComputerscareMetarboWidget>(
+        "computerscare-metarbo");

--- a/src/Metarbo/ComputerscareMetarbo.hpp
+++ b/src/Metarbo/ComputerscareMetarbo.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "../Computerscare.hpp"
+#include "../ComputerscarePolyModule.hpp"
+
+static const int METARBO_NUM_INPUTS = 8;
+static const int METARBO_NUM_OUTPUTS = 8;
+static const int METARBO_NUM_CONTROLS = 8;
+
+enum MetarboViewMode {
+  VIEW_IO_ONLY = 0,
+  VIEW_CONTROLS_IO = 1,
+  VIEW_FULL = 2,
+  NUM_VIEW_MODES = 3
+};
+
+static const char* metarboViewModeNames[] = {
+    "I/O Only", "Controls + I/O", "Full"};
+
+// Width in HP for each view mode
+static const int metarboViewWidths[] = {4, 8, 20};
+
+struct ComputerscareMetarbo : ComputerscarePolyModule {
+  enum ParamIds {
+    VIEW_MODE_PARAM,
+    CONTROL_KNOB,
+    PROGRAM_PARAM = CONTROL_KNOB + METARBO_NUM_CONTROLS,
+    NUM_PARAMS
+  };
+  enum InputIds {
+    SIGNAL_INPUT,
+    NUM_INPUTS = SIGNAL_INPUT + METARBO_NUM_INPUTS
+  };
+  enum OutputIds {
+    SIGNAL_OUTPUT,
+    NUM_OUTPUTS = SIGNAL_OUTPUT + METARBO_NUM_OUTPUTS
+  };
+  enum LightIds { NUM_LIGHTS };
+
+  MetarboViewMode viewMode = VIEW_IO_ONLY;
+  int currentProgram = 0;
+
+  ComputerscareMetarbo() {
+    config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+
+    configSwitch(VIEW_MODE_PARAM, 0.f, 2.f, 0.f, "View Mode",
+                 {"I/O Only", "Controls + I/O", "Full"});
+    getParamQuantity(VIEW_MODE_PARAM)->randomizeEnabled = false;
+    getParamQuantity(VIEW_MODE_PARAM)->resetEnabled = false;
+
+    for (int i = 0; i < METARBO_NUM_CONTROLS; i++) {
+      configParam(CONTROL_KNOB + i, 0.f, 10.f, 0.f,
+                  "Control " + std::to_string(i + 1));
+    }
+
+    configParam(PROGRAM_PARAM, 0.f, 3.f, 0.f, "Program");
+    getParamQuantity(PROGRAM_PARAM)->randomizeEnabled = false;
+    getParamQuantity(PROGRAM_PARAM)->snapEnabled = true;
+
+    for (int i = 0; i < METARBO_NUM_INPUTS; i++) {
+      configInput(SIGNAL_INPUT + i, "Signal " + std::to_string(i + 1));
+    }
+    for (int i = 0; i < METARBO_NUM_OUTPUTS; i++) {
+      configOutput(SIGNAL_OUTPUT + i, "Signal " + std::to_string(i + 1));
+    }
+  }
+
+  void process(const ProcessArgs& args) override {
+    // Sync view mode from param
+    viewMode = (MetarboViewMode)(int)params[VIEW_MODE_PARAM].getValue();
+
+    // Pass-through: each input passes all poly channels to corresponding output
+    for (int i = 0; i < METARBO_NUM_INPUTS; i++) {
+      int channels = inputs[SIGNAL_INPUT + i].getChannels();
+      if (channels == 0) channels = 1;
+      outputs[SIGNAL_OUTPUT + i].setChannels(channels);
+      for (int c = 0; c < channels; c++) {
+        outputs[SIGNAL_OUTPUT + i].setVoltage(
+            inputs[SIGNAL_INPUT + i].getVoltage(c), c);
+      }
+    }
+  }
+
+  json_t* dataToJson() override {
+    json_t* rootJ = json_object();
+    json_object_set_new(rootJ, "viewMode", json_integer((int)viewMode));
+    json_object_set_new(rootJ, "currentProgram", json_integer(currentProgram));
+    return rootJ;
+  }
+
+  void dataFromJson(json_t* rootJ) override {
+    json_t* viewModeJ = json_object_get(rootJ, "viewMode");
+    if (viewModeJ) {
+      viewMode = (MetarboViewMode)json_integer_value(viewModeJ);
+      params[VIEW_MODE_PARAM].setValue((float)viewMode);
+    }
+    json_t* programJ = json_object_get(rootJ, "currentProgram");
+    if (programJ) {
+      currentProgram = json_integer_value(programJ);
+    }
+  }
+};

--- a/src/Metarbo/MetarboControlsIOView.hpp
+++ b/src/Metarbo/MetarboControlsIOView.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "ComputerscareMetarbo.hpp"
+
+// Controls + I/O view: controls on left, inputs, then outputs
+struct MetarboControlsIOView : Widget {
+  ComputerscareMetarbo* module;
+
+  MetarboControlsIOView(ComputerscareMetarbo* mod) {
+    module = mod;
+  }
+
+  static void addControls(ModuleWidget* mw, ComputerscareMetarbo* module) {
+    float controlX = 6.f;
+    float yStart = 46.f;
+    float ySpacing = 38.f;
+
+    for (int i = 0; i < METARBO_NUM_CONTROLS; i++) {
+      mw->addParam(createParam<SmallKnob>(
+          Vec(controlX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::CONTROL_KNOB + i));
+    }
+  }
+
+  static void addPorts(ModuleWidget* mw, ComputerscareMetarbo* module) {
+    float controlsWidth = 30.f;
+    float inputX = controlsWidth + 4.f;
+    float outputX = controlsWidth + 34.f;
+    float yStart = 46.f;
+    float ySpacing = 38.f;
+
+    for (int i = 0; i < METARBO_NUM_INPUTS; i++) {
+      mw->addInput(createInput<InPort>(
+          Vec(inputX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::SIGNAL_INPUT + i));
+    }
+    for (int i = 0; i < METARBO_NUM_OUTPUTS; i++) {
+      mw->addOutput(createOutput<OutPort>(
+          Vec(outputX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::SIGNAL_OUTPUT + i));
+    }
+  }
+
+  static float getWidth() {
+    return metarboViewWidths[VIEW_CONTROLS_IO] * RACK_GRID_WIDTH;
+  }
+};

--- a/src/Metarbo/MetarboFullView.hpp
+++ b/src/Metarbo/MetarboFullView.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "ComputerscareMetarbo.hpp"
+
+// Full view: controls on left, inputs, square display block in middle, outputs
+struct MetarboFullView : Widget {
+  ComputerscareMetarbo* module;
+
+  MetarboFullView(ComputerscareMetarbo* mod) {
+    module = mod;
+  }
+
+  static void addControls(ModuleWidget* mw, ComputerscareMetarbo* module) {
+    float controlX = 6.f;
+    float yStart = 46.f;
+    float ySpacing = 38.f;
+
+    for (int i = 0; i < METARBO_NUM_CONTROLS; i++) {
+      mw->addParam(createParam<SmallKnob>(
+          Vec(controlX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::CONTROL_KNOB + i));
+    }
+  }
+
+  static void addPorts(ModuleWidget* mw, ComputerscareMetarbo* module) {
+    float controlsWidth = 30.f;
+    float inputX = controlsWidth + 4.f;
+    // Square block sits between inputs and outputs
+    float squareSize = 150.f;
+    float outputX = controlsWidth + 34.f + squareSize + 10.f;
+    float yStart = 46.f;
+    float ySpacing = 38.f;
+
+    for (int i = 0; i < METARBO_NUM_INPUTS; i++) {
+      mw->addInput(createInput<InPort>(
+          Vec(inputX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::SIGNAL_INPUT + i));
+    }
+    for (int i = 0; i < METARBO_NUM_OUTPUTS; i++) {
+      mw->addOutput(createOutput<OutPort>(
+          Vec(outputX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::SIGNAL_OUTPUT + i));
+    }
+  }
+
+  static float getWidth() {
+    return metarboViewWidths[VIEW_FULL] * RACK_GRID_WIDTH;
+  }
+};
+
+// Square display block widget for the Full view
+struct MetarboSquareDisplay : Widget {
+  ComputerscareMetarbo* module;
+
+  MetarboSquareDisplay(ComputerscareMetarbo* mod) {
+    module = mod;
+    box.size = Vec(150.f, 150.f);
+  }
+
+  void draw(const DrawArgs& args) override {
+    // Draw a placeholder square
+    nvgBeginPath(args.vg);
+    nvgRect(args.vg, 0, 0, box.size.x, box.size.y);
+    nvgStrokeColor(args.vg, COLOR_COMPUTERSCARE_GREEN);
+    nvgStrokeWidth(args.vg, 2.f);
+    nvgStroke(args.vg);
+
+    nvgFillColor(args.vg, nvgRGBA(0x20, 0x20, 0x20, 0x80));
+    nvgFill(args.vg);
+
+    // Label
+    std::shared_ptr<Font> font =
+        APP->window->loadFont(asset::system("res/fonts/ShareTechMono-Regular.ttf"));
+    if (font) {
+      nvgFontFaceId(args.vg, font->handle);
+      nvgFontSize(args.vg, 14.f);
+      nvgFillColor(args.vg, COLOR_COMPUTERSCARE_GREEN);
+      nvgTextAlign(args.vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+      nvgText(args.vg, box.size.x / 2, box.size.y / 2, "METARBO", NULL);
+    }
+
+    Widget::draw(args);
+  }
+};

--- a/src/Metarbo/MetarboIOView.hpp
+++ b/src/Metarbo/MetarboIOView.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "ComputerscareMetarbo.hpp"
+
+// I/O Only view: narrow module showing just inputs and outputs
+struct MetarboIOView : Widget {
+  ComputerscareMetarbo* module;
+
+  MetarboIOView(ComputerscareMetarbo* mod) {
+    module = mod;
+  }
+
+  // Called by parent widget to add ports when this view is active
+  static void addPorts(ModuleWidget* mw, ComputerscareMetarbo* module) {
+    float inputX = 4.f;
+    float outputX = 34.f;
+    float yStart = 46.f;
+    float ySpacing = 38.f;
+
+    for (int i = 0; i < METARBO_NUM_INPUTS; i++) {
+      mw->addInput(createInput<InPort>(
+          Vec(inputX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::SIGNAL_INPUT + i));
+    }
+    for (int i = 0; i < METARBO_NUM_OUTPUTS; i++) {
+      mw->addOutput(createOutput<OutPort>(
+          Vec(outputX, yStart + ySpacing * i), module,
+          ComputerscareMetarbo::SIGNAL_OUTPUT + i));
+    }
+  }
+
+  static float getWidth() {
+    return metarboViewWidths[VIEW_IO_ONLY] * RACK_GRID_WIDTH;
+  }
+};


### PR DESCRIPTION
- Replace direct `inputs`/`outputs`/`params` member access with
  `getInputs()`/`getOutputs()`/`getParams()` (Rack v2 API)
- Add braces around VIEW_FULL switch case to fix variable initialization
  jump error
- Fix SVG asset paths (res/ not res/components/)
- Register Metarbo module in Computerscare.cpp/.hpp and plugin.json

https://claude.ai/code/session_01NRpTgLVRTEHEV12yuJ7UTy